### PR TITLE
Introducing possibility to use (BSM - SM) difference for SM-like Higgs boson

### DIFF
--- a/python/MSSMvsSM.py
+++ b/python/MSSMvsSM.py
@@ -512,7 +512,7 @@ class MSSMvsSMHiggsModel(PhysicsModel):
             terms += extra
             if ggphi_smlike_match and self.use_hSM_difference:
                 self.modelBuilder.factory_('prod::bsm_scaling_%s(%s)'%(proc,','.join(terms))) # Add scaling of BSM process: mu*SF = x*r*SF
-                self.modelBuilder.factory_('expr::scaling_%s(\"(@0 - @1 * @2)\", %s)'%(proc,','.join(["bsm_scaling_%s"%proc,"x","r"])))
+                self.modelBuilder.factory_('expr::scaling_%s(\"(@0 - @1 * @2)\", %s)'%(proc,','.join(["bsm_scaling_%s"%proc,"x","r"]))) # Add difference between BSM prediction and mu*SM prediction.
             elif bbphi_smlike_match and self.use_hSM_difference and self.replace_with_sm125:
                 self.modelBuilder.factory_('prod::bsm_scaling_%s(%s)'%(proc,','.join(terms)))
                 self.modelBuilder.factory_('expr::scaling_%s(\"(@0 - @1 * @2 * %s * %s)\", %s)'%(proc,str(self.sm_predictions["xs_bb_SMH125"]),str(self.sm_predictions["br_SMH125_tautau"]),','.join(["bsm_scaling_%s"%proc,"x","r"])))

--- a/python/MSSMvsSM.py
+++ b/python/MSSMvsSM.py
@@ -99,6 +99,7 @@ class MSSMvsSMHiggsModel(PhysicsModel):
         self.smlike = "h"
         self.massparameter = "mA"
         self.replace_with_sm125 = True
+        self.use_hSM_difference = False
         self.cpv_template_pairs = {"H1" : "h", "H2" : "H", "H3" : "A"}
 
     def setPhysicsOptions(self,physOptions):
@@ -164,6 +165,11 @@ class MSSMvsSMHiggsModel(PhysicsModel):
             if po.startswith('scaleforh='):
                 self.scaleforh = float(po.replace('scaleforh=',''))
                 print "Additional scale for the light scalar h: {SCALE}".format(SCALE=self.scaleforh)
+
+            if po.startswith('hSM-treatment='):
+                hSM_treatment = po.replace('hSM-treatment=', '')
+                self.use_hSM_difference = hSM_treatment == "hSM-in-bg"
+                print "Using (BSM - SM) difference for SM-like Higgs boson?",self.use_hSM_difference
 
         self.filename = os.path.join(self.filePrefix, self.modelFile)
 
@@ -282,6 +288,8 @@ class MSSMvsSMHiggsModel(PhysicsModel):
 
                 value *= br_htautau / br_htautau_SM # (g_HVV)**2 * br_htautau(mh) / br_htautau_SM(mh), correcting for mass dependence mh vs. 125.4 GeV
                 value *= self.scaleforh # additional manual rescaling of light scalar h (default is 1.0)
+                if self.use_hSM_difference:
+                    value -= 1.0
                 hist.SetBinContent(i_x+1, i_y+1, value)
 
         return self.doHistFunc(name, hist, varlist)
@@ -332,6 +340,8 @@ class MSSMvsSMHiggsModel(PhysicsModel):
 
                 value =  xs_ggh / xs_ggh_SM * br_htautau / br_htautau_SM # xs(mh) * BR(mh) / (xs_SM(mh) * BR_SM(mh)) correcting for mass dependence mh vs. 125.4 GeV
                 value *= self.scaleforh # additional manual rescaling of light scalar h (default is 1.0)
+                if self.use_hSM_difference:
+                    value -= 1.0
                 hist.SetBinContent(i_x+1, i_y+1, value)
 
         return self.doHistFunc(name, hist, varlist)
@@ -378,6 +388,8 @@ class MSSMvsSMHiggsModel(PhysicsModel):
                 # xs(mh) * (xs_SM(125.4)/xs_SM(mh)) * BR(mh) * (BR_SM(125.4)/BR_SM(mh)) correcting for mass dependence mh vs. 125.4 GeV
                 value =  xs_bbh * (xs_bbh_SM125 / xs_bbh_SM) * br_htautau * (br_htautau_SM125 / br_htautau_SM)
                 value *= self.scaleforh # additional manual rescaling of light scalar h (default is 1.0)
+                if self.use_hSM_difference:
+                    value -= 1.0
                 hist.SetBinContent(i_x+1, i_y+1, value)
 
         return self.doHistFunc(name, hist, varlist)

--- a/python/MSSMvsSM.py
+++ b/python/MSSMvsSM.py
@@ -511,7 +511,7 @@ class MSSMvsSMHiggsModel(PhysicsModel):
                     extra += self.SYST_DICT[term]
             terms += extra
             if ggphi_smlike_match and self.use_hSM_difference:
-                self.modelBuilder.factory_('prod::bsm_scaling_%s(%s)'%(proc,','.join(terms)))
+                self.modelBuilder.factory_('prod::bsm_scaling_%s(%s)'%(proc,','.join(terms))) # Add scaling of BSM process: mu*SF = x*r*SF
                 self.modelBuilder.factory_('expr::scaling_%s(\"(@0 - @1 * @2)\", %s)'%(proc,','.join(["bsm_scaling_%s"%proc,"x","r"])))
             elif bbphi_smlike_match and self.use_hSM_difference and self.replace_with_sm125:
                 self.modelBuilder.factory_('prod::bsm_scaling_%s(%s)'%(proc,','.join(terms)))

--- a/run_model-dep-additional_limits.sh
+++ b/run_model-dep-additional_limits.sh
@@ -168,6 +168,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment "hSM-in-bg" \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \
@@ -180,6 +181,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment "hSM-in-bg" \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \
@@ -193,6 +195,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment "hSM-in-bg" \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \

--- a/run_model-dep-full_limits.sh
+++ b/run_model-dep-full_limits.sh
@@ -232,6 +232,7 @@ elif [[ $MODE == "ws" ]]; then
     -P CombineHarvester.MSSMvsSMRun2Legacy.MSSMvsSM:MSSMvsSM \
     --PO filePrefix=${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/ \
     --PO replace-with-SM125=${replace_with_sm125} \
+    --PO hSM-treatment=$HSMTREATMENT \
     --PO modelFile=${modelfile} \
     --PO minTemplateMass=60 \
     --PO maxTemplateMass=3500 \

--- a/run_model-dep-full_limits.sh
+++ b/run_model-dep-full_limits.sh
@@ -244,19 +244,35 @@ elif [[ $MODE == "ws" ]]; then
     # job setup creation
     ############
     cd ${defaultdir}/limits_${MODEL}/condor
-    combineTool.py -M AsymptoticGrid \
-    ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/input/mssm_asymptotic_grid_${MODEL}.json \
-    -d ${datacarddir}/combined/cmb/${wsoutput} \
-    --job-mode 'condor' \
-    --task-name $taskname \
-    --dry-run \
-    --redefineSignalPOI x \
-    --setParameterRanges x=0,1 \
-    --setParameters r=1 \
-    --freezeParameters r -v1 \
-    --cminDefaultMinimizerStrategy 0 \
-    --X-rtd MINIMIZER_analytic \
-    --cminDefaultMinimizerTolerance 0.01 2>&1 | tee -a ${defaultdir}/logs/job_setup_${MODEL}.txt
+    if [[ $HSMTREATMENT == "hSM-in-bg" ]]; then
+        combineTool.py -M AsymptoticGrid \
+        ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/input/mssm_asymptotic_grid_${MODEL}.json \
+        -d ${datacarddir}/combined/cmb/${wsoutput} \
+        --job-mode 'condor' \
+        --task-name $taskname \
+        --dry-run \
+        --redefineSignalPOI r \
+        --setParameterRanges r=0,1 \
+        --setParameters r=1,x=1 \
+        --freezeParameters x -v1 \
+        --cminDefaultMinimizerStrategy 0 \
+        --X-rtd MINIMIZER_analytic \
+        --cminDefaultMinimizerTolerance 0.01 2>&1 | tee -a ${defaultdir}/logs/job_setup_${MODEL}.txt
+    elif [[ $HSMTREATMENT == "no-hSM-in-bg" ]]; then
+        combineTool.py -M AsymptoticGrid \
+        ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/input/mssm_asymptotic_grid_${MODEL}.json \
+        -d ${datacarddir}/combined/cmb/${wsoutput} \
+        --job-mode 'condor' \
+        --task-name $taskname \
+        --dry-run \
+        --redefineSignalPOI x \
+        --setParameterRanges x=0,1 \
+        --setParameters r=1 \
+        --freezeParameters r -v1 \
+        --cminDefaultMinimizerStrategy 0 \
+        --X-rtd MINIMIZER_analytic \
+        --cminDefaultMinimizerTolerance 0.01 2>&1 | tee -a ${defaultdir}/logs/job_setup_${MODEL}.txt
+    fi
 
 elif [[ $MODE == "submit" ]]; then
     ############

--- a/run_model-dep-full_limits.sh
+++ b/run_model-dep-full_limits.sh
@@ -5,7 +5,8 @@ TAG=$1
 MODE=$2
 MODEL=$3
 ANALYSISTYPE=$4
-GRIDUSER=$5
+HSMTREATMENT=$5
+GRIDUSER=$6
 
 if [[ $ANALYSISTYPE == "classic" ]]; then
     analysis="bsm-model-dep-full"
@@ -168,6 +169,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment $HSMTREATMENT  \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \
@@ -180,6 +182,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment $HSMTREATMENT  \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \
@@ -193,6 +196,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment $HSMTREATMENT  \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \

--- a/run_model-dep-full_limits_per_channel.sh
+++ b/run_model-dep-full_limits_per_channel.sh
@@ -6,6 +6,7 @@ MODE=$2
 CHANNEL=$3
 ERA=$4
 MODEL=$5
+HSMTREATMENT=$6
 
 analysis="bsm-model-dep-full"
 sm_like_hists="sm125"
@@ -104,6 +105,7 @@ if [[ $MODE == "initial" ]]; then
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
         --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${HSMTREATMENT} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \
@@ -116,6 +118,7 @@ if [[ $MODE == "initial" ]]; then
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
         --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${HSMTREATMENT} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \

--- a/run_model-dep-full_limits_per_channel.sh
+++ b/run_model-dep-full_limits_per_channel.sh
@@ -148,6 +148,7 @@ elif [[ $MODE == "ws" ]]; then
     -P CombineHarvester.MSSMvsSMRun2Legacy.MSSMvsSM:MSSMvsSM \
     --PO filePrefix=${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/ \
     --PO replace-with-SM125=${replace_with_sm125} \
+    --PO hSM-treatment=$HSMTREATMENT \
     --PO modelFile=${modelfile} \
     --PO minTemplateMass=60 \
     --PO maxTemplateMass=3500 \

--- a/run_model-dep-full_limits_per_era.sh
+++ b/run_model-dep-full_limits_per_era.sh
@@ -5,6 +5,7 @@ TAG=$1
 MODE=$2
 ERA=$3
 ANALYSISTYPE=$4
+HSMTREATMENT=$5
 
 if [[ $ANALYSISTYPE == "classic" ]]; then
     analysis="bsm-model-dep-full"
@@ -50,6 +51,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment ${HSMTREATMENT} \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \
@@ -61,6 +63,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment ${HSMTREATMENT} \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \
@@ -73,6 +76,7 @@ if [[ $MODE == "initial" ]]; then
         morph_parallel.py --output ${defaultdir}/datacards \
             --analysis ${analysis} \
             --sub-analysis ${sub_analysis} \
+            --hSM-treatment ${HSMTREATMENT} \
             --categorization ${categorization} \
             --sm-like-hists ${sm_like_hists} \
             --sm-gg-fractions ${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/higgs_pt_reweighting_fullRun2_v2.root \

--- a/run_model-dep-full_limits_per_era.sh
+++ b/run_model-dep-full_limits_per_era.sh
@@ -102,6 +102,7 @@ elif [[ $MODE == "ws" ]]; then
     -P CombineHarvester.MSSMvsSMRun2Legacy.MSSMvsSM:MSSMvsSM \
     --PO filePrefix=${CMSSW_BASE}/src/CombineHarvester/MSSMvsSMRun2Legacy/data/ \
     --PO replace-with-SM125=${replace_with_sm125} \
+    --PO hSM-treatment=$HSMTREATMENT \
     --PO modelFile=13,Run2017,mh125_13.root \
     --PO minTemplateMass=60 \
     --PO maxTemplateMass=3500 \

--- a/run_model-indep_classic_limits.sh
+++ b/run_model-indep_classic_limits.sh
@@ -10,7 +10,7 @@ fi
 
 defaultdir=analysis/$TAG
 analysis="bsm-model-indep"
-sub_analysis="hSM-in-bg"
+hSM_treatment="hSM-in-bg"
 categorization="classic"
 sm_like_hists="bsm"
 [[ ! -d ${defaultdir} ]] && mkdir -p ${defaultdir}
@@ -27,7 +27,7 @@ if [[ $MODE == "initial" ]]; then
     ############
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --eras 2016,2017,2018 \

--- a/run_model-indep_with-ml-cats_limits.sh
+++ b/run_model-indep_with-ml-cats_limits.sh
@@ -10,7 +10,7 @@ fi
 
 defaultdir=analysis/$TAG
 analysis="bsm-model-indep"
-sub_analysis="hSM-in-bg"
+hSM_treatment="hSM-in-bg"
 categorization="with-sm-ml"
 sm_like_hists="bsm"
 [[ ! -d ${defaultdir} ]] && mkdir -p ${defaultdir}
@@ -28,7 +28,7 @@ if [[ $MODE == "initial" ]]; then
     ############
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --eras 2016,2017,2018 \
@@ -40,7 +40,7 @@ if [[ $MODE == "initial" ]]; then
 
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --eras 2016,2017,2018 \

--- a/run_model-indep_with-ml-cats_limits_per_channel.sh
+++ b/run_model-indep_with-ml-cats_limits_per_channel.sh
@@ -19,7 +19,7 @@ fi
 
 defaultdir=analysis/$TAG
 analysis="bsm-model-indep"
-sub_analysis="hSM-in-bg"
+hSM_treatment="hSM-in-bg"
 categorization="with-sm-ml"
 sm_like_hists="bsm"
 [[ ! -d ${defaultdir} ]] && mkdir -p ${defaultdir}
@@ -37,7 +37,7 @@ if [[ $MODE == "initial" ]]; then
     ############
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --eras 2016,2017,2018 \
@@ -49,7 +49,7 @@ if [[ $MODE == "initial" ]]; then
 
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --eras 2016,2017,2018 \

--- a/run_sm_classic_signal_stage0.sh
+++ b/run_sm_classic_signal_stage0.sh
@@ -10,7 +10,7 @@ fi
 
 defaultdir=analysis/$TAG
 analysis="sm"
-sub_analysis="no-hSM-in-bg"
+hSM_treatment="no-hSM-in-bg"
 categorization="classic"
 sm_like_hists="sm125"
 [[ ! -d ${defaultdir} ]] && mkdir -p ${defaultdir}
@@ -25,7 +25,7 @@ if [[ $MODE == "initial" ]]; then
     ############
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --eras 2016,2017,2018 \

--- a/run_sm_ml-cats-only_signal_stage0.sh
+++ b/run_sm_ml-cats-only_signal_stage0.sh
@@ -10,7 +10,7 @@ fi
 
 defaultdir=analysis/$TAG
 analysis="sm"
-sub_analysis="no-hSM-in-bg"
+hSM_treatment="no-hSM-in-bg"
 categorization="sm-ml-only"
 sm_like_hists="sm125"
 [[ ! -d ${defaultdir} ]] && mkdir -p ${defaultdir}
@@ -25,7 +25,7 @@ if [[ $MODE == "initial" ]]; then
     ############
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} --sm \
         --eras 2016,2017,2018 \

--- a/run_sm_with-sm-ml_signal_stage0.sh
+++ b/run_sm_with-sm-ml_signal_stage0.sh
@@ -10,7 +10,7 @@ fi
 
 defaultdir=analysis/$TAG
 analysis="sm"
-sub_analysis="no-hSM-in-bg"
+hSM_treatment="no-hSM-in-bg"
 categorization="with-sm-ml"
 sm_like_hists="sm125"
 [[ ! -d ${defaultdir} ]] && mkdir -p ${defaultdir}
@@ -25,7 +25,7 @@ if [[ $MODE == "initial" ]]; then
     ############
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} --sm \
         --eras 2016,2017,2018 \
@@ -37,7 +37,7 @@ if [[ $MODE == "initial" ]]; then
 
     morph_parallel.py --output ${defaultdir}/datacards \
         --analysis ${analysis} \
-        --sub-analysis ${sub_analysis} \
+        --hSM-treatment ${hSM_treatment} \
         --categorization ${categorization} \
         --sm-like-hists ${sm_like_hists} \
         --eras 2016,2017,2018 \

--- a/scripts/morph_parallel.py
+++ b/scripts/morph_parallel.py
@@ -18,6 +18,7 @@ parser = argparse.ArgumentParser( description = "Compare Integrals of Processes 
 parser.add_argument('--output-folder', required = True, help = "Main folder, where the datacards should be created")
 parser.add_argument('--analysis', required = True, help = "Analysis to be prepared with morphing")
 parser.add_argument('--sub-analysis', required = True, help = "Sub-analysis to be prepared with morphing")
+parser.add_argument('--hSM-treatment', required = True, help = "hSM treatment to be used")
 parser.add_argument('--categorization', required = True, help = "Categorization type to be prepared with morphing")
 parser.add_argument('--sm-like-hists', required = True, help = "Templates type for SM like Higss boson to be prepared with morphing")
 parser.add_argument('--category-list', required = True, help = "Category list, which will be used for parallelization of morphing")
@@ -41,14 +42,14 @@ eras = args.eras.split(',')
 commands = []
 
 command_template = "MorphingMSSMvsSM --era={ERA} --category={CATEGORY} --output_folder={OUTPUT}" \
-                   " --analysis={ANALYSIS} --sub-analysis={SUB_ANALYSIS} --categorization={CATEGORIZATION} --sm-like-hists={SM_LIKE_HISTS}" \
+                   " --analysis={ANALYSIS} --sub-analysis={SUB_ANALYSIS} --hSM-treatment={HSM_TREATMENT} --categorization={CATEGORIZATION} --sm-like-hists={SM_LIKE_HISTS}" \
                    " --variable={VARIABLE} --sm_gg_fractions={SM_GG_FRACTIONS} {ADDITIONALARGS}"
 
 for era in eras:
     for category in categories:
         command = command_template.format(ERA=era, CATEGORY=category, ANALYSIS=args.analysis,
                                           ADDITIONALARGS=args.additional_arguments, OUTPUT=args.output_folder,
-                                          VARIABLE=args.variable, SM_GG_FRACTIONS=args.sm_gg_fractions,
+                                          VARIABLE=args.variable, SM_GG_FRACTIONS=args.sm_gg_fractions, HSM_TREATMENT=args.hSM_treatment,
                                           SUB_ANALYSIS=args.sub_analysis, CATEGORIZATION=args.categorization, SM_LIKE_HISTS=args.sm_like_hists)
         commands.append(command)
 


### PR DESCRIPTION
This commit introduces (BSM - SM) difference for SM-like Higgs boson, which can be used in model-dependent limits, when comparing the full neutral BSM Higgs boson spectrum with the SM hypothesis including a SM Higgs boson.

This approach retains the idea of MSSM vs. SM hypothesis testing, while introducing a nested way of including a BSM Higgs boson spectrum, such that asymptotic formula can be used again, in contrast to the toy-based TeV tests performed in HIG-17-020